### PR TITLE
ci: fix the Windows MFC build, the branch triggers, and the placeholder test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,45 +1,140 @@
 name: Main pipeline
 
+# Triggers
+# --------
+# The previous config used `branches-ignore: ['*']`, intended to disable push
+# builds. It did not work as intended: `*` does not match `/`, so branches like
+# `port/cross-platform` still triggered a run while `master` did not. And
+# `pull_request` only fired for PRs into `master`, so PRs into the port branch
+# got no checks at all. Both are spelled out explicitly below.
 on:
   push:
-    branches-ignore:
-      - '*'
+    branches:
+      - master
+      - port/cross-platform
+      - 'phase*/**'
+      - 'ci/**'
+      - 'docs/**'
   pull_request:
     branches:
       - master
+      - port/cross-platform
+  workflow_dispatch:
 
 jobs:
-  test:
-    runs-on: windows-latest
-
+  # ---------------------------------------------------------------------------
+  # Portable checks. These run everywhere and are the only signal available to
+  # developers on macOS/Linux, who cannot build the MFC application at all.
+  # Both jobs no-op cleanly on branches where the relevant paths do not exist.
+  # ---------------------------------------------------------------------------
+  data-verify:
+    name: Verify extracted language data
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
-
-      - name: Setup VSTest Path
-        uses: darenm/Setup-VSTest@v1.2
-      
-      # msbuild VinaText.sln /t:Rebuild
-      # vstest.console.exe VinaText.exe
-      - name: Run unit tests
-        shell: cmd
+      - name: Probe for the extractor
+        id: probe
         run: |
-          echo Tests succeeded
+          if [ -f tools/extract_language_data.py ]; then
+            echo "present=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=no" >> "$GITHUB_OUTPUT"
+            echo "tools/extract_language_data.py not on this branch - skipping"
+          fi
 
-  build:
-    runs-on: windows-latest
-    needs: test
+      # Asserts the JSON in Packages/data-packages still reproduces the C++
+      # tables in src/EditorColor{Light,Dark}.h exactly. Guards against the two
+      # drifting apart while both are present in the tree.
+      - name: Round-trip JSON against the C++ tables
+        if: steps.probe.outputs.present == 'yes'
+        run: python3 tools/extract_language_data.py --verify
 
+  core-tests:
+    name: core/ tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Probe for core/
+        id: probe
+        run: |
+          if [ -f core/LanguageData.cpp ]; then
+            echo "present=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=no" >> "$GITHUB_OUTPUT"
+            echo "core/ not on this branch - skipping"
+          fi
+
+      - name: Build and run
+        if: steps.probe.outputs.present == 'yes'
+        run: |
+          set -euo pipefail
+          c++ -std=c++11 -Wall -Wextra -Werror \
+              -I include -I core \
+              core/LanguageData.cpp core/tests/TestLanguageData.cpp \
+              -o testlangdata
+          ./testlangdata
+
+  # ---------------------------------------------------------------------------
+  # The Windows MFC build. This is the regression test that matters: per D5 the
+  # MFC frontend must keep building throughout the port, and on a long-lived
+  # branch (D4) this job is the only thing checking that.
+  # ---------------------------------------------------------------------------
+  windows-build:
+    name: MFC build (Release|x64)
+    # Pinned deliberately, NOT windows-latest. windows-latest has rolled to
+    # VS 18, whose image does not ship MFC/ATL - that is what was failing with
+    # "error MSB8041: MFC libraries are required for this project". The project
+    # is <UseOfMfc>Dynamic</UseOfMfc> on PlatformToolset v143, which is VS 2022.
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
 
-      - name: Build
+      # The pinned image is expected to already carry ATL/MFC. Verify rather
+      # than assume, and install on demand if a future image drops it, so this
+      # fails with a clear message instead of MSB8041 deep inside the build.
+      - name: Ensure MFC/ATL components are present
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $withMfc = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.ATLMFC -property installationPath
+          if ($withMfc) {
+            Write-Host "MFC present: $withMfc"
+            exit 0
+          }
+          Write-Host "MFC not found - installing Microsoft.VisualStudio.Component.VC.ATLMFC"
+          $installPath = & $vswhere -latest -products * -property installationPath
+          if (-not $installPath) { throw "no Visual Studio installation found" }
+          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
+          $p = Start-Process -FilePath $installer -Wait -PassThru -ArgumentList @(
+            "modify", "--installPath", "`"$installPath`"",
+            "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC",
+            "--quiet", "--norestart", "--nocache"
+          )
+          if ($p.ExitCode -ne 0) { throw "vs_installer failed with exit code $($p.ExitCode)" }
+          Write-Host "MFC installed"
+
+      # Release|x64 only. The solution also declares Win32 configurations, but
+      # no 32-bit binaries are shipped and lib/ only carries x64 prebuilts.
+      - name: Build VinaText.sln
         shell: cmd
-        run: msbuild VinaText.sln /p:Configuration=Release /p:Platform=x64
+        run: msbuild VinaText.sln /p:Configuration=Release /p:Platform=x64 /m /v:minimal /nologo
+
+      - name: Upload build output
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: VinaText-Release-x64
+          path: |
+            bin/x64/Release/VinaText.exe
+          if-no-files-found: warn
+          retention-days: 7

--- a/src/VinaText.vcxproj
+++ b/src/VinaText.vcxproj
@@ -108,7 +108,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING;WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\boost;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -134,7 +134,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp14</LanguageStandard>
@@ -163,7 +163,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\..\boost;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -191,7 +191,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING;_CRT_SECURE_NO_WARNINGS;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>


### PR DESCRIPTION
The pipeline was red on **every branch, including the untouched `master` commit** — this is pre-existing breakage, not fallout from the port work. Three independent problems.

### 1. `windows-latest` no longer ships MFC

```
error MSB8041: MFC libraries are required for this project.
```

`windows-latest` has rolled to **VS 18** (`C:\Program Files\Microsoft Visual Studio\18\Enterprise`), and that image doesn't include MFC/ATL. The project is `<UseOfMfc>Dynamic</UseOfMfc>` on `PlatformToolset v143`, so it can't build there at all.

Pinned to `windows-2022`, which matches v143, plus a `vswhere` check that installs `Microsoft.VisualStudio.Component.VC.ATLMFC` on demand if a future image drops it — so this fails with a clear message instead of MSB8041 deep inside the build.

### 2. The triggers didn't do what they looked like

`branches-ignore: ['*']` was meant to disable push builds. It doesn't: **`*` does not match `/`**, so `port/cross-platform` and `phase*/` branches triggered runs while `master` did not — the exact inverse of the intent. And `pull_request` only fired for PRs into `master`, so PRs into the port branch (#54, #55) got no checks at all.

Both are now explicit, and cover `master` and the port branches.

### 3. `std::locale::empty()` broke the build on current toolsets

```
src/PathUtil.cpp(925,37): error C4996: 'std::locale::empty'  [STL4048]
```

A non-Standard Microsoft extension, now deprecated. Because the project sets `<SDLCheck>true</SDLCheck>`, `/sdl` escalates C4996 from warning to **error** — so the build breaks on any toolset newer than whatever the team has locally.

Added `_SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING` to the four `ClCompile` configurations. That's Microsoft's documented macro for this case and changes no behaviour.

> **Deliberately not fixing the call site.** The obvious rewrites are not equivalent — `locale::empty()` yields a locale with *no facets*, `locale()` copies the *current global* locale, `locale::classic()` is the *C* locale. This sits inside `FileContentToUtf8`, so choosing wrong changes how files decode: a data-correctness bug in a text editor. That needs someone who can actually run the app.
>
> **It has a deadline** — the extension is slated for *removal*, not just deprecation. Worth a follow-up issue.

Only `locale::empty()` is affected. The `codecvt_utf8` deprecations in `PathUtil.cpp`, `AppUtil.cpp` and `VinaTextApp.cpp` are C++17-only and the project builds `stdcpp14`, so they don't fire yet — they will if the standard is ever raised.

### 4. Replaced the placeholder test job

The old `test` job pulled in a third-party VSTest action and then ran `echo Tests succeeded`. Replaced with two real jobs:

| Job | What it does |
|---|---|
| `data-verify` | Round-trips `Packages/data-packages/*.json` against the C++ tables in `src/EditorColor{Light,Dark}.h` |
| `core-tests` | Builds and runs `core/tests` on ubuntu + macos with `-Wall -Wextra -Werror` |

Both probe for their inputs and skip cleanly on branches that don't have them, so **this PR is safe to merge ahead of #55**, which is what adds `core/` and `tools/`.

### Result

All four jobs green, and the Windows job produces a real `VinaText.exe` artifact (2.3 MB), so it's building rather than silently no-op'ing.

```
success  MFC build (Release|x64)          2m08s
success  Verify extracted language data     11s
success  core/ tests (ubuntu-latest)         7s
success  core/ tests (macos-latest)         10s
```

### Why this matters beyond going green

Per **D5** the MFC frontend must keep building throughout the port, and per **D4** that work now lives on a long-lived branch rather than `master`. The Windows job is the only thing checking that. Until it existed, every Phase 1–2 task was unverifiable for anyone not on Windows — which is the whole team's constraint on this port.

Suggest merging this first, then rebasing #54 and #55 onto it so they pick up real checks.
